### PR TITLE
Fix orgs.length rendering 0 when .length is 0

### DIFF
--- a/src/screens/user/components/profile/profile.js
+++ b/src/screens/user/components/profile/profile.js
@@ -41,7 +41,7 @@ function Profile({user, orgs}) {
         </Login>
       </Section>
       <ProfileStatsSection user={user} />
-      {orgs.length && <OrganizationsSection orgs={orgs} />}
+      {!!orgs.length && <OrganizationsSection orgs={orgs} />}
     </div>
   )
 }


### PR DESCRIPTION
Cast `orgs.length` to boolean value, otherwise React will render 0

![image](https://user-images.githubusercontent.com/410792/29454465-e92e6c7e-843f-11e7-9b44-c4d137074545.png)
